### PR TITLE
db.has([Object Boolean]) return value fix

### DIFF
--- a/lib/has.js
+++ b/lib/has.js
@@ -13,6 +13,6 @@ module.exports = function(db, params, options) {
   if (params.ops.target) fetched = get(fetched, params.ops.target); // Get prop using dot notation
 
   // Return boolean
-  return (fetched ? true : false);
+  return (typeof fetched != 'undefined');
   
 } // Papa bless, you here? I think we need update, push wasn't working.


### PR DESCRIPTION
Original code in default branch returns value of [Object Boolean] instead of whether it exists. This edit changes the return value to if the fetched object exists (or more precisely, if it is defined).