### PR TITLE
Allowed null for value when using set()

### DIFF
--- a/bin/handler.js
+++ b/bin/handler.js
@@ -52,7 +52,7 @@ module.exports = {
   
   set: function(key, value, ops) {
     if (!key) throw new TypeError('No key specified. Need Help? Check Out: discord.gg/plexidev');
-    if (!value && value != 0) throw new TypeError('No value specified. Need Help? Check Out: discord.gg/plexidev');
+    if (value === undefined) throw new TypeError('No value specified. Need Help? Check Out: discord.gg/plexidev');
     return arbitrate('set', {stringify: true, id: key, data: value, ops: ops || {}});
   },
   


### PR DESCRIPTION
`null` should be allowed as a value, it would be real useful. As for undefined, you could always ignore it, but i suggest you should also allow it. Since `null` and `undefined` can be turned into strings. So it won't break the sqlite database.