### PR TITLE
Replace singular Lodash dependencies with core package

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -1,6 +1,6 @@
 // Require Packages
-const get = require('lodash.get');
-const set = require('lodash.set');
+const get = require('lodash/get');
+const set = require('lodash/set');
 
 module.exports = function(db, params, options) {
   

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -1,5 +1,5 @@
 // Require Packages
-const unset = require('lodash.unset');
+const unset = require('lodash/unset');
 
 module.exports = function(db, params, options) {
   

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,5 +1,5 @@
 // Require Packages
-const get = require('lodash.get');
+const get = require('lodash/get');
 
 module.exports = function(db, params, options) {
   

--- a/lib/has.js
+++ b/lib/has.js
@@ -1,5 +1,5 @@
 // Require Packages
-const get = require('lodash.get');
+const get = require('lodash/get');
 
 module.exports = function(db, params, options) {
   

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,6 +1,6 @@
 // Require Packages
-const get = require('lodash.get');
-const set = require('lodash.set');
+const get = require('lodash/get');
+const set = require('lodash/set');
 
 module.exports = function(db, params, options) {
   

--- a/lib/set.js
+++ b/lib/set.js
@@ -1,5 +1,5 @@
 // Require Packages
-const set = require('lodash.set');
+const set = require('lodash/set');
 
 module.exports = function(db, params, options) {
   

--- a/lib/subtract.js
+++ b/lib/subtract.js
@@ -1,6 +1,6 @@
 // Require Packages
-const get = require('lodash.get');
-const set = require('lodash.set');
+const get = require('lodash/get');
+const set = require('lodash/set');
 
 module.exports = function(db, params, options) {
   

--- a/lib/type.js
+++ b/lib/type.js
@@ -1,5 +1,5 @@
 // Require Packages
-const get = require('lodash.get');
+const get = require('lodash/get');
 
 module.exports = function(db, params, options) {
   

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "better-sqlite3": "^5.0.1",
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2",
-    "lodash.unset": "^4.5.2"
+    "lodash": "4.17.15"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
The use of Lodash Per-Method packages are discouraged and will be [removed in v5](https://lodash.com/per-method-packages).